### PR TITLE
Enhance WeChat MP template handling and add server log header filteri…

### DIFF
--- a/app/api/wechat_mp.go
+++ b/app/api/wechat_mp.go
@@ -452,7 +452,7 @@ func (c *weChatMPClient) sendTemplateWithToken(
 		"thing10": {"value": truncateWeChatTemplateValue(req.ProjectName, 20)},
 		"thing5":  {"value": truncateWeChatTemplateValue(req.TriggerCondition, 20)},
 		"thing8":  {"value": truncateWeChatTemplateValue(req.TriggerSource, 20)},
-		"time21":  {"value": truncateWeChatTemplateValue(req.TriggerTime, 20)},
+		"time14":  {"value": truncateWeChatTemplateValue(req.TriggerTime, 20)},
 	}
 	payload := map[string]any{
 		"touser":      req.OpenID,

--- a/app/api/wechat_mp_test.go
+++ b/app/api/wechat_mp_test.go
@@ -123,12 +123,27 @@ func TestWeChatMPSendRefreshesInvalidTokenAndMapsTemplateFields(t *testing.T) {
 		t.Fatalf("unexpected template payload: %#v", sentPayload)
 	}
 	data := sentPayload["data"].(map[string]any)
+	if len(data) != 5 {
+		t.Fatalf("unexpected template data: %#v", data)
+	}
 	thing4 := data["thing4"].(map[string]any)["value"].(string)
 	if got := len([]rune(thing4)); got != 20 {
 		t.Fatalf("thing4 length = %d, want 20", got)
 	}
 	if data["thing10"].(map[string]any)["value"] != "AI 创业" {
 		t.Fatalf("unexpected project name: %#v", data["thing10"])
+	}
+	if data["thing5"].(map[string]any)["value"] != "评分88分，阈值75分" {
+		t.Fatalf("unexpected trigger condition: %#v", data["thing5"])
+	}
+	if data["thing8"].(map[string]any)["value"] != "微博" {
+		t.Fatalf("unexpected trigger source: %#v", data["thing8"])
+	}
+	if data["time14"].(map[string]any)["value"] != "2026-07-27 12:30:00" {
+		t.Fatalf("unexpected trigger time: %#v", data["time14"])
+	}
+	if _, exists := data["time21"]; exists {
+		t.Fatalf("obsolete time21 field is still present: %#v", data)
 	}
 }
 

--- a/app/pkg/middleware/serverlog.go
+++ b/app/pkg/middleware/serverlog.go
@@ -233,6 +233,7 @@ var hideShowHeaders = map[string]bool{
 	"accept":                true,
 	"accept-encoding":       true,
 	"proxy-connection":      true,
+	"x-avm-wechat-secret":   true,
 	"x-envoy-peer-metadata": true,
 }
 

--- a/app/pkg/middleware/serverlog_test.go
+++ b/app/pkg/middleware/serverlog_test.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestFilterHeadersHidesAVMWeChatSecret(t *testing.T) {
+	headers := http.Header{
+		"Content-Type":        {"application/json"},
+		"X-Avm-Wechat-Secret": {"bridge-secret"},
+	}
+
+	filtered := filterHeaders(headers, map[string]bool{}, hideShowHeaders)
+
+	if got := filtered.Get("X-AVM-WeChat-Secret"); got != "" {
+		t.Fatalf("X-AVM-WeChat-Secret leaked into logs: %q", got)
+	}
+	if got := filtered.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	if got := headers.Get("X-AVM-WeChat-Secret"); got != "bridge-secret" {
+		t.Fatalf("request headers were mutated: %q", got)
+	}
+}


### PR DESCRIPTION
…ng tests

- Updated WeChat MP template to replace obsolete 'time21' field with 'time14'.
- Added validation for new template fields in the test for WeChat MP.
- Introduced a new test to ensure sensitive headers are filtered from logs in the middleware.